### PR TITLE
Add dep on Cairo.pm @ fix-pdf-outline-export

### DIFF
--- a/maint/cpanfile-git
+++ b/maint/cpanfile-git
@@ -1,3 +1,6 @@
+requires 'Cairo',
+	git => 'https://gitlab.gnome.org/zmughal/perl-cairo.git',
+	branch => 'fix-pdf-outline-export';
 requires 'Renard::Incunabula',
 	git => 'https://github.com/project-renard/p5-Renard-Incunabula.git',
 	branch => 'master';


### PR DESCRIPTION
This fixes a build bug for MSYS2/MINGW.

Links with <https://gitlab.gnome.org/GNOME/perl-cairo/-/merge_requests/1>.