### PR TITLE
Use upstream Cairo@1.109 from CPAN

### DIFF
--- a/maint/cpanfile-git
+++ b/maint/cpanfile-git
@@ -1,6 +1,3 @@
-requires 'Cairo',
-	git => 'https://gitlab.gnome.org/zmughal/perl-cairo.git',
-	branch => 'fix-pdf-outline-export';
 requires 'Renard::Incunabula',
 	git => 'https://github.com/project-renard/p5-Renard-Incunabula.git',
 	branch => 'master';


### PR DESCRIPTION
Removes dep on Cairo.git@fix-pdf-outline-export branch

Changes from branch were merged upstream and in the Cairo-1.109 release
<https://metacpan.org/changes/release/XAOC/Cairo-1.109#L4>.
